### PR TITLE
Save all counts into counts_table.npz

### DIFF
--- a/inStrain/profileUtilities.py
+++ b/inStrain/profileUtilities.py
@@ -493,6 +493,7 @@ def _update_snp_table_T(Stable, clonT, clonTR, MMcounts, p2c,\
     ret_counts = np.zeros(4, dtype=int)
     for mm in sorted(list(MMcounts.keys())):
         counts = _mm_counts_to_counts(MMcounts, mm)
+        ret_counts = counts
         snp, morphia = call_snv_site(counts, refBase, min_cov=min_cov, min_freq=min_freq) # Call SNP
 
         # Update clonality
@@ -531,7 +532,6 @@ def _update_snp_table_T(Stable, clonT, clonTR, MMcounts, p2c,\
                anySNP = True
                bases.add(snp)
                bases.add(varbase)
-               ret_counts = counts
 
            elif (morphia == 1) & (anySNP == True):
                p2c[pos] = True


### PR DESCRIPTION
This PR modifies inStrain behaviour in writing counts to the counts array. Instead of writing just the counts of segregating sites, it records every site.

I did some testing and it seems that the outputs remain the same (with the exception of `counts_table.npz`).

I'm unsure if the current behaviour was intentional. If so, please ignore this PR.

My main motivation was that there are some common metrics that are calculated over regions within the scaffolds and they require allele counts of both segregating and fixed alleles.