### PR TITLE
modify conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ pip install instrain
 
 ### bioconda
 ```
-$ conda config --add channels bioconda; conda install instrain
+$ conda install -c conda-forge -c bioconda -c defaults instrain
 ```
 
 ### Docker


### PR DESCRIPTION
First, thanks for all your work on this and excellent documentation!

Just a suggestion on the conda install instructions :)

For many packages from bioconda to install properly, more channels need to be set in a specific hierarchy (e.g. https://bioconda.github.io/user/install.html#set-up-channels). Some installs work fine regardless, some will fail, and some will have more insidious issues. 

But that still requires a separate step of people changing their channels. I prefer listing bioconda installs like so:

`conda install -c conda-forge -c bioconda -c defaults instrain`

Because we get in one line everything that's needed, and regardless of what system we hop onto we don't need to worry about changing the underlying conda config channel structure.