### PR TITLE
added per-group processing for inStrain compare

### DIFF
--- a/inStrain/argumentParser.py
+++ b/inStrain/argumentParser.py
@@ -183,13 +183,29 @@ def parse_args(args):
     compare_parent = argparse.ArgumentParser(add_help=False)
     # Required positional arguments
     Rflags = compare_parent.add_argument_group('REQUIRED')
-    Rflags.add_argument('-i', '--input', help="A list of inStrain objects, all mapped to the same .fasta file",
+    Rflags.add_argument('-i', '--input',
+                        help="A list of inStrain objects, all mapped to the same .fasta file",
                         nargs='*', required=True)
     Rflags.add_argument("-o", "--output", action="store", default='instrainComparer', \
                         help='Output prefix')
+    Gflags = compare_parent.add_argument_group('GROUPS')
+    Gflags.add_argument('--list-groups', help="List all groups", action='store_true',
+                        default=False, required=False)
+    Gflags.add_argument('--group-pkl', help="Pickled group object",
+                        default=None, type=str, required=False)
+    Gflags.add_argument('--group', help="Specific group to compare",
+                        default=None, type=int, required=False)
+    Gflags.add_argument('--comparisons',
+                        help="All comparison pkl files (if previously used --group)",
+                        default=None, required=False, nargs='+')
+    Gflags.add_argument('--comparisons-list',
+                        help="A file list all pcomparison pkl files (if previously used --group). One file per line",
+                        default=None, required=False)
 
     compare_parser = subparsers.add_parser("compare",formatter_class=SmartFormatter,\
-                    parents = [compare_parent, parent_parser, geneomewide_parent, variant_parent], add_help=False)
+                                           parents = [compare_parent, parent_parser,
+                                                      geneomewide_parent, variant_parent],
+                                           add_help=False)
 
     # Database mode parameters
     Dflags = compare_parser.add_argument_group('DATABASE MODE PARAMETERS')
@@ -255,7 +271,9 @@ def parse_args(args):
     '''
     # Make a parent for profile to go above the system arguments
     genome_parser = subparsers.add_parser("genome_wide",formatter_class=SmartFormatter,\
-                    parents = [geneomewide_parent, genes_io, mm_parent, parent_parser], add_help=False)
+                                          parents = [geneomewide_parent, genes_io,
+                                                     mm_parent, parent_parser],
+                                          add_help=False)
 
     '''
     ####### Arguments for plot operation ######


### PR DESCRIPTION
I quickly tried changing the code to allow for single-group processing by `inStrain compare`. While the group processing time is uneven, such as this run:

```
Running group 1 of 148
Comparing scaffolds: 100%|██████████| 646/646 [16:30:21<00:00, 91.98s/it]
Running group 2 of 148
Comparing scaffolds: 100%|██████████| 944/944 [1:14:30<00:00,  4.74s/it]
Running group 3 of 148
Comparing scaffolds: 100%|██████████| 781/781 [20:18<00:00,  1.56s/it]
Running group 4 of 148
Comparing scaffolds: 100%|██████████| 760/760 [19:07<00:00,  1.51s/it]
Running group 5 of 148
Comparing scaffolds: 100%|██████████| 754/754 [25:51<00:00,  2.06s/it]
Running group 6 of 148
Comparing scaffolds: 100%|██████████| 891/891 [23:32<00:00,  1.59s/it]
Running group 7 of 148
Comparing scaffolds: 100%|██████████| 781/781 [35:10<00:00,  2.70s/it]
Running group 8 of 148
Comparing scaffolds: 100%|██████████| 819/819 [22:09<00:00,  1.62s/it]
Running group 9 of 148
Comparing scaffolds: 100%|██████████| 805/805 [22:26<00:00,  1.67s/it]
Running group 10 of 148
Comparing scaffolds: 100%|██████████| 904/904 [04:52<00:00,  3.09it/s]
Running group 11 of 148
Comparing scaffolds: 100%|██████████| 901/901 [04:47<00:00,  3.13it/s]
Running group 12 of 148
Comparing scaffolds: 100%|██████████| 960/960 [04:49<00:00,  3.32it/s]
Running group 13 of 148
Comparing scaffolds: 100%|██████████| 982/982 [07:27<00:00,  2.19it/s]
Running group 14 of 148
Comparing scaffolds: 100%|██████████| 1023/1023 [05:45<00:00,  2.96it/s]
Running group 15 of 148
Comparing scaffolds: 100%|██████████| 932/932 [05:26<00:00,  2.85it/s]
Running group 16 of 148
Comparing scaffolds: 100%|██████████| 929/929 [09:30<00:00,  1.63it/s]
Running group 17 of 148
Comparing scaffolds: 100%|██████████| 872/872 [03:08<00:00,  4.63it/s]
Running group 18 of 148
Comparing scaffolds: 100%|██████████| 887/887 [02:48<00:00,  5.26it/s]
Running group 19 of 148
Comparing scaffolds: 100%|██████████| 1333/1333 [06:01<00:00,  3.69it/s]
Running group 20 of 148
Comparing scaffolds:  99%|█████████▉| 1174/1180 [09:32<08:50, 88.43s/it]
[...]
```

...parallel processing of each group separately can save some time (many hours in this example).

I couldn't really find any good testing datasets in `./tests/`, so I used my own, but here is the general workflow for parallel processing of groups:

```
INDIRS="2_T3_scaffold_info.tsv 93_T3_scaffold_info.tsv"   # my data files
OUTDIR=tmp/compare_step

# listing groups and creating a pickle file of the group object
inStrain compare --min_cov 5 --min_freq 0.05 --ani_threshold 0.99999 -p 8 \
-s /ebio/abt3_scratch/nyoungblut/LLMGPS_55977766656/inStrain/genomes.stb  -o $OUTDIR -i $INDIRS \
--list-groups

# processing group 1 (output saved to $OUTDIR/groups/1.pkl)
inStrain compare --min_cov 5 --min_freq 0.05 --ani_threshold 0.99999 -p 8 \
-s /ebio/abt3_scratch/nyoungblut/LLMGPS_55977766656/inStrain/genomes.stb  -o $OUTDIR -i $INDIRS \
--group-pkl $OUTDIR/groups.pkl --group 1

# processing group 1 (output saved to $OUTDIR/groups/2.pkl)
inStrain compare --min_cov 5 --min_freq 0.05 --ani_threshold 0.99999 -p 8 \
-s /ebio/abt3_scratch/nyoungblut/LLMGPS_55977766656/inStrain/genomes.stb  -o $OUTDIR -i $INDIRS \
--group-pkl  $OUTDIR/groups.pkl --group 2

# merging the results (the user could also use  --comparisons-list for large sets of groups)
inStrain compare --min_cov 5 --min_freq 0.05 --ani_threshold 0.99999 -p 8 \
-s /ebio/abt3_scratch/nyoungblut/LLMGPS_55977766656/inStrain/genomes.stb  -o $OUTDIR -i $INDIRS \
--comparisons  $OUTDIR/groups/1.pkl  $OUTDIR/groups/2.pkl
```

...while the basic functionality remains intact:

```
# standard serial processing of groups
OUTDIR=tmp/compare
inStrain compare --min_cov 5 --min_freq 0.05 --ani_threshold 0.99999 -p 8 \
-s /ebio/abt3_scratch/nyoungblut/LLMGPS_55977766656/inStrain/genomes.stb  -o $OUTDIR -i $INDIRS
```

The output for both approaches is the same, although it appears that your code allows for variable ordering of the output table columns, probably due to using a dict. Using an ordered dict will stabilize the column order. 

Sorry for not keeping the code style consistent with you. Please just consider this an example/guide on how this could be done. 