### PR TITLE
Suppress Pandas FutureWarning

### DIFF
--- a/inStrain/genomeUtilities.py
+++ b/inStrain/genomeUtilities.py
@@ -945,7 +945,7 @@ def generate_genome_coverage_array(covT, s2l, order=None, maxMM=100, mask_edges=
         if scaff in covT:
             cov = inStrain.profile.profile_utilities.mm_counts_to_counts_shrunk(covT[scaff], maxMM=maxMM, fill_zeros=slen)
         else:
-            cov = pd.Series(index=np.arange(slen))
+            cov = pd.Series(index=np.arange(slen), dtype="float64")
 
 
         if mask_edges:


### PR DESCRIPTION
Hi, this is just a trivial edit to prevent this warning:

```
cov = pd.Series(index=np.arange(slen))
/var/lib/miniconda3/envs/ebame/lib/python3.8/site-packages/inStrain/genomeUtilities.py:948: 
FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version.
Specify a dtype explicitly to silence this warning.
```

Thanks,
V