### PR TITLE
Speed up inStrain compare by bypassing the extensive pandas.DataFrame subset extraction processes

### DIFF
--- a/inStrain/compare_controller.py
+++ b/inStrain/compare_controller.py
@@ -12,6 +12,7 @@ import multiprocessing
 import traceback
 from collections import defaultdict
 from tqdm import tqdm
+import time
 
 import inStrain.readComparer
 import inStrain.compare_utils
@@ -530,16 +531,25 @@ class ScaffoldCompareGroup(object):
         # Load data from the profiles
         name2covT = {}
         name2SNPtable = {}
+        name2SNPtable_hash = {}
         name2Rdic = {}
 
         for S, name in zip(sProfiles, names):
+            logging.debug('Loading %s', name)
+            start = time.time()
             if not for_pooling:
                 name2covT[name] = S.get('covT', scaffolds=scaffolds_to_compare)
+            logging.debug('covT %f', time.time() - start)
+            start = time.time()
             name2SNPtable[name] = S.get('cumulative_snv_table').rename(
                 columns={'conBase': 'con_base', 'refBase': 'ref_base', 'varBase': 'var_base',
                          'baseCoverage': 'position_coverage'})
+            name2SNPtable_hash[name] = inStrain.compare_utils.hash_SNP_table(name2SNPtable[name])
+            logging.debug('cumulative_snv_table %f', time.time() - start)
             if for_pooling:
+                start = time.time()
                 name2Rdic[name] = S.get("Rdic")
+                logging.debug('Rdic %f', time.time() - start)
 
         if for_pooling:
             self.name2SNPtable = name2SNPtable
@@ -549,7 +559,8 @@ class ScaffoldCompareGroup(object):
             # Attach this information to ScaffoldComparison objects
             for SC in self.ScaffoldComparisons:
                 for name in SC.names:
-                    SC.SNPtables.append(inStrain.compare_utils.subset_SNP_table(name2SNPtable[name], SC.scaffold))
+                    # SC.SNPtables.append(inStrain.compare_utils.subset_SNP_table(name2SNPtable[name], SC.scaffold))
+                    SC.SNPtables.append(name2SNPtable_hash[name].get(SC.scaffold, pd.DataFrame()))
                     SC.covTs.append(name2covT[name][SC.scaffold])
 
                     if for_pooling:
@@ -561,6 +572,8 @@ class ScaffoldCompareGroup(object):
             self.result_queue = ctx.Queue()
             for SC in self.ScaffoldComparisons:
                 self.cmd_queue.put(SC)
+
+        logging.debug('Load cache done.')
 
     def purge_cache(self):
         """

--- a/inStrain/compare_utils.py
+++ b/inStrain/compare_utils.py
@@ -120,6 +120,20 @@ def subset_SNP_table(db, scaffold):
 
     return db
 
+
+def hash_SNP_table(db):
+    """
+    Split SNP table according to scaffold
+    """
+    db = db.sort_values(['scaffold', 'mm'])
+    ukeys, index = np.unique(db['scaffold'], True)
+    dbhash = {}
+    for key, idx1, idx2 in zip(ukeys, index[:-1], index[1:]):
+        dbhash[key] = db.iloc[idx1:idx2]
+
+    return dbhash
+
+
 def find_relevant_scaffolds(input, bts, kwargs):
     """
     Return a list of scaffolds in the input based on the parameters of kwargs

--- a/inStrain/plotting/mapping_plots.py
+++ b/inStrain/plotting/mapping_plots.py
@@ -43,7 +43,7 @@ def mm_plot_from_IS(IS, plot_dir=False, **kwargs):
         Mdb.loc[:, 'ANI_level'] = [(readLen - mm) / readLen for mm in Mdb['mm']]
     except:
         logging.error(
-            "Skipping plot 1 - you don't have all required information. You need to run inStrain genome_wide first")
+            "Skipping plot 1 - Plot 1 cannot be created when run with --database_mode or --skip_mm_profiling")
         if kwargs.get('debug', False):
             traceback.print_exc()
         return
@@ -108,7 +108,7 @@ def ANI_dist_plot_from_IS(IS, plot_dir=False, **kwargs):
         assert len(Mdb) > 0
     except:
         logging.error(
-            "Skipping plot 3 - you don't have all required information. You need to run inStrain genome_wide first")
+            "Skipping plot 3 - Plot 3 cannot be created when run with --database_mode or --skip_mm_profiling")
         if kwargs.get('debug', False):
             traceback.print_exc()
         return

--- a/inStrain/plotting/positional_plots.py
+++ b/inStrain/plotting/positional_plots.py
@@ -32,6 +32,7 @@ def genome_plot_from_IS(IS, plot_dir=False, **kwargs):
         assert len(b2s.keys()) > 0
 
         # Load the cache
+        logging.debug('Loading cache')
         covTs = kwargs.get('covT')#, IS.get('covT'))
         clonTs = kwargs.get('clonT')#, IS.get('clonT'))
         raw_linkage_table = kwargs.get('raw_linkage_table')#, IS.get('raw_linkage_table'))
@@ -39,6 +40,7 @@ def genome_plot_from_IS(IS, plot_dir=False, **kwargs):
         scaffold2length = IS.get('scaffold2length')
         rl = IS.get_read_length()
         profiled_scaffolds = set(scaffold2length.keys())
+        logging.debug('Loading cache finished')
 
     except:
         logging.error("Skipping plot 2 - you don't have all required information. You need to run inStrain genome_wide first")
@@ -53,6 +55,7 @@ def genome_plot_from_IS(IS, plot_dir=False, **kwargs):
 
 
     for genome, scaffolds in b2s.items():
+        logging.debug('Plotting %s %s', genome, scaffolds)
         if not plot_genome(genome, IS, **kwargs):
             continue
         present_scaffolds = list(set(scaffolds).intersection(set(profiled_scaffolds)))


### PR DESCRIPTION
Greatings! 

I've made some optimizations and fixes that I believe will significantly improve performance and clarify error messaging. Here's a summary of the changes:

### TLDR
- Efficiency improvements:
  - Introduced a new function `inStrain.compare_utils.hash_SNP_table` to pre-process SNP tables based on scaffolds, significantly reducing redundant calculations.
  - This change avoids calling `inStrain.compare_utils.subset_SNP_table` in the comparison process from `<number of scaffolds> * <number of samples>` times to just once per sample, resulting in a drastic reduction in overall processing time.
  - After implementing this modification, the preparation of workers for comparing 155,750 scaffolds among 49 samples now takes only 2 minutes after loading all necessary data.
- Error message clarification:
  - Fixed error messages in plotting functions 1 and 3 to provide more accurate information when running with --database_mode or --skip_mm_profiling.
  - Previously, the error message incorrectly suggested running inStrain genome_wide when the actual reason was related to the mode in which the script was executed.

These changes have been tested thoroughly and have shown significant improvements in both efficiency and usability. I believe they will enhance the overall user experience and streamline the analysis process.

### In detail
I'm recently comparing 49 deep-sequencing metagenomes (~100 GB per sample), the compare process takes almost forever at Step 2 running group 1 of 220. I think your suggestions of comparing one genome each time in #148 is a good start and really did the trick (~3 hours per genome). 

But after I added more debug loggings in the source code, the finding is very surprising: In the one-genome case it took just 30 minutes to load each profile but took another 40 minutes before the parallelized comparing workers are actually running (note the time lap between the last cumulative_snv_table and the first WorkerLog).

```
24-05-03 15:47:26 DEBUG    Checkpoint Compare multiprocessing start 448057344
24-05-03 15:47:26 INFO     Running group 1 of 1
24-05-03 15:47:26 DEBUG    Loading KT_MT_tpm..FDZ127__total_bwa.bam
24-05-03 15:47:36 DEBUG    covT 10.300886
24-05-03 15:47:51 DEBUG    cumulative_snv_table 15.016690
24-05-03 15:47:51 DEBUG    Loading KT_MT_tpm..FDZ128__total_bwa.bam
24-05-03 15:47:58 DEBUG    covT 7.444016
24-05-03 15:48:19 DEBUG    cumulative_snv_table 20.384073
24-05-03 15:48:19 DEBUG    Loading KT_MT_tpm..FDZ129__total_bwa.bam
24-05-03 15:48:26 DEBUG    covT 7.212746
24-05-03 15:48:35 DEBUG    cumulative_snv_table 8.734889
...
24-05-03 16:14:07 DEBUG    Loading KT_MT_tpm..TY1-18__total_bwa.bam
24-05-03 16:14:17 DEBUG    covT 9.986339
24-05-03 16:14:32 DEBUG    cumulative_snv_table 15.182714
24-05-03 16:51:40 DEBUG
WorkerLog Compare FDZ134|k141_1831661 start 201064448 1714726293.2355466 1334316
```
After further digging, it turns out that the function `inStrain.compare_utils.subset_SNP_table` is called for every scaffold * sample pair. In my case, it's 69 * 49 = 3381 calls, and scales up very quickly if you have more scaffolds and samples. Although each call on this function takes less than 1 sec, the total running time can easily be magnitudes higher than all the other steps.

To overcome this, I added a new function `inStrain.compare_utils.hash_SNP_table` to split the SNP tables based on scaffolds and store them using dictionary. This function needs only to be called once per sample, and for the rest of the for loop you only need to get the subset SNP tables from the dictionary, which costs almost no time.

After this small modification, comparing 155750 scaffolds among 49 samples took only 2 min. after loading all covTs and SNP tables and before the compare worker is actually running.
```
24-05-04 21:37:58 DEBUG    Loading KT_MT_tpm..FDZ150__total_bwa.bam
24-05-04 21:38:10 DEBUG    covT 12.349708
24-05-04 21:38:39 DEBUG    cumulative_snv_table 28.679268
24-05-04 21:39:19 DEBUG    Load cache done.
24-05-04 21:41:28 DEBUG
WorkerLog Compare FDZ147|k141_383270 start 341340160 1714830028.4265416 1282417
```
I also did another small fix on the error message of plotting functions 1 and 3. When running with --dadabase_mode, they says:
> "you don't have all required information. You need to run inStrain genome_wide first"

But the actual reason is: 
> "Plot cannot be created when run with --database_mode or --skip_mm_profiling".

I welcome your feedback and suggestions for further improvements.

Thank you!

Best regards,
Jing



