### PR TITLE
Fix biopython >=1.78 compatibility (codon table import)

### DIFF
--- a/inStrain/GeneProfile.py
+++ b/inStrain/GeneProfile.py
@@ -21,9 +21,12 @@ from concurrent import futures
 from inStrain import SNVprofile
 from collections import defaultdict
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from Bio.codonalign.codonalphabet import default_codon_table
+try:
+    from Bio.Data.CodonTable import standard_dna_table as default_codon_table
+except ImportError:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from Bio.codonalign.codonalphabet import default_codon_table
 
 import inStrain.SNVprofile
 import inStrain.controller


### PR DESCRIPTION
## Summary
- `Bio.codonalign.codonalphabet` was removed in biopython 1.76+, causing `ModuleNotFoundError` on import
- Replace with `Bio.Data.CodonTable.standard_dna_table` (modern API)
- Includes fallback to old import for biopython <=1.75 compatibility
- Fixes #27 and #31

## Change
```python
# Before:
from Bio.codonalign.codonalphabet import default_codon_table

# After:
try:
    from Bio.Data.CodonTable import standard_dna_table as default_codon_table
except ImportError:
    from Bio.codonalign.codonalphabet import default_codon_table
```

## Test
Verified `standard_dna_table.forward_table` and `standard_dna_table.stop_codons` work identically to the old `default_codon_table` — both are `NCBICodonTableDNA` instances.