### PR TITLE
Fix off-by-one in generate_snp_model (draft — see #223)

### DIFF
--- a/inStrain/profile/snv_utilities.py
+++ b/inStrain/profile/snv_utilities.py
@@ -11,13 +11,22 @@ import inStrain.profile.profile_utilities
 P2C = {'A':0, 'C':1, 'T':2, 'G':3} # base -> position
 C2P = {0:'A', 1:'C', 2:'T', 3:'G'} # position -> base
 
-def generate_snp_model(model_file, fdr=1e-6):
+def generate_snp_model(model_file, fdr=1e-6, legacy_thresholds=False):
     '''
     The model_file contains the columns "coverage", "probability of X coverage base by random chance"
 
     The model that it returns has the properties:
         model[position_coverage] = the minimum number of alternate bases to be legit
         model[-1] = use this value if coverage is not in dictionary
+
+    The data columns of model_file hold the number of alternate bases (k = 1, 2, 3, ...),
+    so column k lives at index k - 1. Enumerating from 1 stores the read count itself
+    rather than its column index; storing the index made the returned thresholds one
+    read lower than intended, so the realized false-positive rate was that of the
+    preceding column rather than fdr.
+
+    legacy_thresholds: reproduce the previous (one-read-lower) thresholds, for
+        re-analysing data processed with earlier versions.
     '''
     f = open(model_file)
     model = {}
@@ -26,12 +35,10 @@ def generate_snp_model(model_file, fdr=1e-6):
             continue
         counts = line.split()[1:]
         coverage = line.split()[0]
-        i = 0 # note 6.4.20 - this should be 1, not zero
-        for count in counts:
+        for k, count in enumerate(counts, start=1):
             if float(count) < fdr:
-                model[int(coverage)] = i
+                model[int(coverage)] = k - 1 if legacy_thresholds else k
                 break
-            i += 1
 
     model[-1] = max(model.values())
 

--- a/test/tests/test_snv_utilities.py
+++ b/test/tests/test_snv_utilities.py
@@ -1,0 +1,60 @@
+"""
+Tests for SNV utility functions
+"""
+
+import os
+import tempfile
+
+import inStrain
+import inStrain.profile.snv_utilities
+
+
+def _null_model_loc():
+    """The NullModel.txt that ships with inStrain, resolved as the controllers do."""
+    return os.path.join(os.path.dirname(inStrain.__file__), 'helper_files', 'NullModel.txt')
+
+
+def test_generate_snp_model_stores_read_counts():
+    """The model must store the read count whose probability is below fdr, not its index.
+
+    Uses a synthetic table so the assertion depends only on the parsing logic, not on
+    the Monte-Carlo values in the shipped file. With fdr=1e-6:
+      coverage 10 -> the first column below 1e-6 is the 3rd (k=3)
+      coverage 20 -> the first column below 1e-6 is the 2nd (k=2)
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        table = os.path.join(tmpdir, 'SyntheticNullModel.txt')
+        with open(table, 'w') as o:
+            o.write('coverage\t1\t2\t3\t4\n')
+            o.write('10\t0.01\t0.001\t0.0000001\t0.0\n')
+            o.write('20\t0.02\t0.0000005\t0.0\t0.0\n')
+
+        model = inStrain.profile.snv_utilities.generate_snp_model(table, fdr=1e-6)
+        assert model[10] == 3, model[10]
+        assert model[20] == 2, model[20]
+        assert model[-1] == 3, model[-1]
+
+        legacy = inStrain.profile.snv_utilities.generate_snp_model(
+            table, fdr=1e-6, legacy_thresholds=True)
+        assert legacy[10] == 2, legacy[10]
+        assert legacy[20] == 1, legacy[20]
+
+
+def test_generate_snp_model_on_shipped_table():
+    """Spot-check the real table.
+
+    At coverage 30 the row is 0.02998 (k=1), 0.00018 (k=2), 1e-06 (k=3), 0.0 (k=4);
+    the first value strictly below 1e-6 is k=4, so an allele needs 4 reads.
+    At coverage 5 the row reaches 0.0 at k=3.
+    """
+    model = inStrain.profile.snv_utilities.generate_snp_model(_null_model_loc(), fdr=1e-6)
+    assert model[5] == 3, model[5]
+    assert model[30] == 4, model[30]
+
+    legacy = inStrain.profile.snv_utilities.generate_snp_model(
+        _null_model_loc(), fdr=1e-6, legacy_thresholds=True)
+    assert legacy[5] == 2, legacy[5]
+    assert legacy[30] == 3, legacy[30]
+
+    # legacy_thresholds must reproduce the previous behaviour at every coverage.
+    assert all(legacy[c] == model[c] - 1 for c in model if c > 0)


### PR DESCRIPTION
Fixes the off-by-one reported in #223.

## What changed

`generate_snp_model` scanned a coverage's row of `NullModel.txt` and stored the *index* of the first column below `--fdr`. The data columns are numbers of variant reads (k = 1, 2, 3, …), so column k sits at index k − 1, and the stored value was then consumed as a read count by `is_present` and `call_snv_site`. Every threshold therefore came out one read lower than the documented rule, and the realized per-position false-positive rate was the preceding column's value rather than `fdr`.

This enumerates from 1 so the stored value is the read count, and adds `legacy_thresholds=False` so previous behaviour can be reproduced exactly when re-analysing older results.

At coverage 30 with the default `--fdr 1e-6`, the row is 0.02998 (k=1), 0.00018 (k=2), 1e-06 (k=3), 0.0 (k=4). The first value strictly below 1e-6 is k=4, so the minimum becomes 4 reads where it was previously 3.

## Tests

Adds `test/tests/test_snv_utilities.py` with two pure-function tests (no BAMs, ~3 seconds):

- a synthetic table with hand-chosen probabilities, so the assertion depends only on the parsing logic rather than the Monte-Carlo values in the shipped file;
- a spot check against the shipped `NullModel.txt` (coverage 5 → 3 reads, coverage 30 → 4), plus a check that `legacy_thresholds=True` reproduces the previous value at every coverage.

Both pass locally against inStrain 1.10.0's dependencies.

